### PR TITLE
Some typo-like fixes

### DIFF
--- a/4-Addressing_Modes_and_Data_Types.md
+++ b/4-Addressing_Modes_and_Data_Types.md
@@ -155,7 +155,7 @@ LD A,(IX + 231AH)     ;load into the accumulator
 | Register | Before<br/> instruction execution | After<br/>instruction execution |
 |-|-|-|
 |A  | 23 | 3D
-|BC | 01FE | 01FE |
+|IX | 01FE | 01FE |
 
 |Data memory<br/> address | Data memory<br/> value |
 |-|-|
@@ -193,7 +193,7 @@ LD A,(IX - 1)     ;load into the accumulator
 | Register | Before<br/> instruction execution | After<br/>instruction execution |
 |-|-|-|
 |A  | 01 | 3D
-|BC | 203A | 203A |
+|IX | 203A | 203A |
 
 |Data memory<br/> address | Data memory<br/> value |
 |-|-|
@@ -339,7 +339,8 @@ LD A,(HL + IX)     ;load into the accunulator the
 | Register | Before<br/> instruction execution | After<br/>instruction execution |
 |-|-|-|
 |A  | BC | A2
-|HL | FFFE | FFFE |
+|HL | 1502 | 1502 |
+|IX | FFFE | FFFE |
 
 |Data memory<br/> address | Data memory<br/> value |
 |-|-|

--- a/5-Instruction_Set.md
+++ b/5-Instruction_Set.md
@@ -672,7 +672,7 @@ IR | ADC A,(HL) | `10 001 110`
 DA | ADC A,(addr)   | `11 011 101` `10 001 111` ` addr(low)  ` ` addr(high) `
 X | ADC A,(XX + dd) | `11 111 101` `10 001 xx ` `   d(low)   ` `  d(high)   `
 SX | ADC A,(XY + d) | `11 *11 101` `10 001 110` `     d      `
-RA | ADC A,<addr> | `11 111 101` `10 001 000` ` disp(low)  ` ` disp(high) `
+RA | ADC A,\<addr> | `11 111 101` `10 001 000` ` disp(low)  ` ` disp(high) `
 SR | ADC A,(SP + dd) | `11 011 101` `10 001 000` `   d(low)   ` `  d(high)   `
 BX | ADC A,(XXA + XXB) | `11 011 101` `10 001 bx `
 
@@ -894,7 +894,7 @@ IR | ADD A,(HL) | `10 000 110`
 DA | ADD A,(addr) | `11 011 101` `10 000 111` ` addr(low)  ` ` addr(high) `
 X | ADD A,(XX + dd) | `11 111 101` `10 000 xx ` `   d(low)   ` `  d(high)   `
 SX | ADD A,(XY + d) | `11 *11 101` `10 000 110` `     d      `
-RA | ADD A,<addr> | `11 111 101` `10 000 000` ` disp(low)  ` ` disp(high) `
+RA | ADD A,\<addr> | `11 111 101` `10 000 000` ` disp(low)  ` ` disp(high) `
 SR | ADD A,(SP + dd) | `11 011 101` `10 000 000` `   d(low)   ` `  d(high)   `
 BX | ADD A,(XXA + XXB) | `11 011 101` `10 000 bx `
 

--- a/5-Instruction_Set.md
+++ b/5-Instruction_Set.md
@@ -2059,7 +2059,7 @@ DI mask | `11 101 101` `01 110 111` `    mask    `
 
 Mask = byte specifying which interrupts to disable: mask(i) corresponds to interrupt source i; mask(7) must be zero.
 
-### Eample
+### Example
 
 DI 23H
 
@@ -2137,7 +2137,7 @@ IR | DIV HL,(HL) | `11 101 101` `11 100 100`
 **xx:** 001 for (IX + dd), 010 for (IY + dd), 011 for (HL + dd)<br/>
 **bx:** 001 for (HL + IX), 010 for (HL + IY), 011 for (IX + IY)
 
-### Eample
+### Example
 
 DIV HL,C
 
@@ -2219,7 +2219,7 @@ IR | DIVU HL,(HL) | `11 101 101` `11 110 101`
 **xx:** 001 for (IX + dd), 010 for (IY + dd), 011 for (HL + dd)<br/>
 **bx:** 001 for (HL + IX), 010 for (HL + IY), 011 for (IX + IY)
 
-### Eample
+### Example
 
 DIVU HL,C
 
@@ -2297,7 +2297,7 @@ IR | DIVUW DEHL,(HL) | `11 011 101` `11 101 101` `11 001 011`
 **rr:** 001 for BC, 011 for DE, 101 for HL, 111 for SP<br/>
 **xy:** 001 for (IX + dd), 011 for (IY + dd)
 
-### Eample
+### Example
 
 DIVUW DEHL,6
 
@@ -2375,7 +2375,7 @@ IR | DIVW DEHL,(HL) | `11 011 101` `11 101 101` `11 001 010`
 **rr:** 001 for BC, 011 for DE, 101 for HL, 111 for SP<br/>
 **xy:** 001 for (IX + dd), 011 for (IY + dd)
 
-### Eample
+### Example
 
 DIUW DEHL,6
 
@@ -2425,7 +2425,7 @@ None
 |-|-|
 DJNZ addr | `00 010 000` `    disp    `
 
-### Eample
+### Example
 
 DJNZ 1050H
 

--- a/5-Instruction_Set.md
+++ b/5-Instruction_Set.md
@@ -672,7 +672,7 @@ IR | ADC A,(HL) | `10 001 110`
 DA | ADC A,(addr)   | `11 011 101` `10 001 111` ` addr(low)  ` ` addr(high) `
 X | ADC A,(XX + dd) | `11 111 101` `10 001 xx ` `   d(low)   ` `  d(high)   `
 SX | ADC A,(XY + d) | `11 *11 101` `10 001 110` `     d      `
-RA | ADC A,\<addr> | `11 111 101` `10 001 000` ` disp(low)  ` ` disp(high) `
+RA | ADC A,&lt;addr&gt; | `11 111 101` `10 001 000` ` disp(low)  ` ` disp(high) `
 SR | ADC A,(SP + dd) | `11 011 101` `10 001 000` `   d(low)   ` `  d(high)   `
 BX | ADC A,(XXA + XXB) | `11 011 101` `10 001 bx `
 
@@ -894,7 +894,7 @@ IR | ADD A,(HL) | `10 000 110`
 DA | ADD A,(addr) | `11 011 101` `10 000 111` ` addr(low)  ` ` addr(high) `
 X | ADD A,(XX + dd) | `11 111 101` `10 000 xx ` `   d(low)   ` `  d(high)   `
 SX | ADD A,(XY + d) | `11 *11 101` `10 000 110` `     d      `
-RA | ADD A,\<addr> | `11 111 101` `10 000 000` ` disp(low)  ` ` disp(high) `
+RA | ADD A,&lt;addr&gt; | `11 111 101` `10 000 000` ` disp(low)  ` ` disp(high) `
 SR | ADD A,(SP + dd) | `11 011 101` `10 000 000` `   d(low)   ` `  d(high)   `
 BX | ADD A,(XXA + XXB) | `11 011 101` `10 000 bx `
 

--- a/B-Z280_MPU_Instruction_Formats.md
+++ b/B-Z280_MPU_Instruction_Formats.md
@@ -54,7 +54,7 @@ _Table B-2. Format 2 Instruction Encodings_
 | | | Instruction Format | | Assembly | Machine Code (Hex)
 |-|-|-|-|-|-|
 | | CB | opcode | | RLC (HL) | CB 06
-| A.esc | CB | 1-byte displacement | opcode | RCL (IX + d) | DD CB d 06
+| A.esc | CB | 1-byte displacement | opcode | RLC (IX + d) | DD CB d 06
 
 _Table B-3. Format 3 Instruction Encodings_
 


### PR DESCRIPTION
There are two `<addr>` fixes in ADD and ADC in chapter 5 to make them display at github.

And few typo-like fixes of text, which are maybe part of original book (I didn't check) - I'm not sure if you want to fix these, or you are aiming at perfect transcript including all original errors.

So cherry-pick changes you want, TY. :)
(I just fixed some of these along quickly reading through it, fixing it was not my goal, so this is just by-product).